### PR TITLE
Use legvander on full feature matrix

### DIFF
--- a/src/skpoly/_legendre.py
+++ b/src/skpoly/_legendre.py
@@ -37,10 +37,9 @@ class LegendreFeatures(_BasePolynomialBasisTransformer):
         return ((X - lower) * 2.0 / span) - 1.0
 
     def _evaluate_basis(self, X: np.ndarray) -> np.ndarray:
-        vanders = [legvander(X[:, i], self.degree) for i in range(X.shape[1])]
-        if not vanders:
+        if X.shape[1] == 0:
             return np.empty((X.shape[0], 0, self.degree + 1), dtype=np.float64)
-        return np.stack(vanders, axis=1)
+        return legvander(X, self.degree)
 
 
 __all__ = ["LegendreFeatures"]


### PR DESCRIPTION
## Summary
- simplify the Legendre basis evaluation by applying `legvander` to the full feature matrix at once
- preserve handling for empty feature matrices while avoiding per-column iteration

## Testing
- not run (library change)


------
https://chatgpt.com/codex/tasks/task_e_68d6d2c34b74832d9c99fd3267900b06