### PR TITLE
Fix Bernstein features to use binomial pmf

### DIFF
--- a/src/skpoly/__init__.py
+++ b/src/skpoly/__init__.py
@@ -1,7 +1,8 @@
 """Polynomial basis transformers compatible with scikit-learn."""
 
-from ._bernstein import BernsteinFeatures
 from ._legendre import LegendreFeatures
+
+from ._bernstein import BernsteinFeatures
 
 __all__ = [
     "BernsteinFeatures",

--- a/src/skpoly/_bernstein.py
+++ b/src/skpoly/_bernstein.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.polynomial.bernstein import bvander
+from scipy.stats import binom
 
 from ._base import _BasePolynomialBasisTransformer
 
@@ -36,9 +36,15 @@ class BernsteinFeatures(_BasePolynomialBasisTransformer):
         return (X - lower) / (upper - lower)
 
     def _evaluate_basis(self, X: np.ndarray) -> np.ndarray:
-        vanders = [bvander(X[:, i], self.degree) for i in range(X.shape[1])]
-        if not vanders:
+        if X.shape[1] == 0:
             return np.empty((X.shape[0], 0, self.degree + 1), dtype=np.float64)
+
+        orders = np.arange(self.degree + 1)
+        vanders = []
+        for column in range(X.shape[1]):
+            probabilities = binom.pmf(orders, self.degree, X[:, [column]])
+            vanders.append(probabilities.astype(np.float64, copy=False))
+
         return np.stack(vanders, axis=1)
 
 

--- a/tests/test_polynomial_features.py
+++ b/tests/test_polynomial_features.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+
+from skpoly import BernsteinFeatures, LegendreFeatures
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"degree": -1}, "degree must be a non-negative integer"),
+        ({"feature_range": (0.0,)}, "feature_range must be a tuple of two floats"),
+        ({"feature_range": (0.0, np.inf)}, "feature_range values must be finite"),
+        ({"feature_range": (1.0, 0.0)}, "feature_range must satisfy a < b"),
+        ({"include_bias": "yes"}, "include_bias must be a boolean"),
+        ({"tensor_product": 1}, "tensor_product must be a boolean"),
+    ],
+)
+def test_legendre_constructor_validates_parameters(kwargs, message):
+    transformer = LegendreFeatures(**kwargs)
+    X = np.zeros((2, 1), dtype=float)
+    with pytest.raises(ValueError, match=message):
+        transformer.fit(X)
+
+
+def test_missing_values_produce_zero_features_legendre():
+    transformer = LegendreFeatures(degree=2, include_bias=True)
+    training_data = np.array([[0.0], [1.0]], dtype=float)
+    transformer.fit(training_data)
+
+    test_data = np.array([[np.nan], [0.5]], dtype=float)
+    transformed = transformer.transform(test_data)
+
+    expected_second_row = np.array([1.0, 0.0, -0.5])
+    expected = np.vstack([
+        np.zeros_like(expected_second_row),
+        expected_second_row,
+    ])
+    np.testing.assert_allclose(transformed, expected)
+
+
+def test_tensor_products_vanish_when_a_column_is_missing():
+    transformer = LegendreFeatures(degree=1, include_bias=True, tensor_product=True)
+    training_data = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+        ],
+        dtype=float,
+    )
+    transformer.fit(training_data)
+
+    test_data = np.array([[np.nan, 0.5]], dtype=float)
+    transformed = transformer.transform(test_data)
+
+    expected = np.array([[0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]])
+    np.testing.assert_allclose(transformed, expected)
+
+
+def test_multi_column_transform_matches_single_column_concatenation():
+    params = dict(degree=2, include_bias=True, tensor_product=False)
+    training_data = np.array(
+        [
+            [0.0, 0.25],
+            [1.0, 0.75],
+        ],
+        dtype=float,
+    )
+    multi_column = LegendreFeatures(**params).fit(training_data)
+
+    test_sample = np.array([[0.5, 0.25]], dtype=float)
+    combined = multi_column.transform(test_sample)
+
+    single_column_features = []
+    for column in range(training_data.shape[1]):
+        column_transformer = LegendreFeatures(**params).fit(training_data[:, [column]])
+        single_column_features.append(column_transformer.transform(test_sample[:, [column]]))
+    stacked = np.concatenate(single_column_features, axis=1)
+
+    np.testing.assert_allclose(combined, stacked)
+
+
+def test_bernstein_basis_matches_known_values():
+    transformer = BernsteinFeatures(degree=2, include_bias=True)
+    training_data = np.array([[0.0], [1.0]], dtype=float)
+    transformer.fit(training_data)
+
+    midpoint = np.array([[0.5]], dtype=float)
+    transformed = transformer.transform(midpoint)
+
+    expected = np.array([[0.25, 0.5, 0.25]])
+    np.testing.assert_allclose(transformed, expected)


### PR DESCRIPTION
## Summary
- import `BernsteinFeatures` unconditionally so the class is always available
- compute the Bernstein basis with `scipy.stats.binom.pmf`, avoiding the non-existent NumPy helper
- run the Bernstein unit test unconditionally now that the implementation is reliable

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d511ec90832daa0120def74f1896