### PR TITLE
Configure hatch build metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "skpoly"
@@ -8,17 +8,31 @@ version = "0.1.0"
 description = "Polynomial basis transformers for scikit-learn."
 authors = [{name = "Alex Shtoff"}]
 readme = "LICENSE"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+keywords = ["polynomials", "scikit-learn", "feature-engineering", "machine-learning"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "numpy>=1.24",
     "scikit-learn>=1.3",
+    "scipy>=1.10",
 ]
 
-[tool.setuptools]
-package-dir = {"" = "src"}
+[project.urls]
+Homepage = "https://github.com/axshtoff/skpoly"
+Repository = "https://github.com/axshtoff/skpoly"
+"Bug Tracker" = "https://github.com/axshtoff/skpoly/issues"
 
-[tool.setuptools.packages.find]
-where = ["src"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/torchcurves"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
## Summary
- switch the project to the hatchling build backend and configure the wheel target
- bump the supported Python version to 3.10 and include SciPy as a dependency
- add publish-ready metadata including license text, classifiers, keywords, and project URLs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6dd3a2704832d8b7f04515558fe13