### PR TITLE
Clip scaled inputs for Bernstein and Legendre bases

### DIFF
--- a/src/skpoly/_bernstein.py
+++ b/src/skpoly/_bernstein.py
@@ -33,7 +33,8 @@ class BernsteinFeatures(_BasePolynomialBasisTransformer):
 
     def _scale_to_basis(self, X: np.ndarray) -> np.ndarray:
         lower, upper = self.feature_range_
-        return (X - lower) / (upper - lower)
+        scaled = (X - lower) / (upper - lower)
+        return np.clip(scaled, 0.0, 1.0, out=scaled)
 
     def _evaluate_basis(self, X: np.ndarray) -> np.ndarray:
         if X.shape[1] == 0:

--- a/src/skpoly/_legendre.py
+++ b/src/skpoly/_legendre.py
@@ -34,7 +34,8 @@ class LegendreFeatures(_BasePolynomialBasisTransformer):
     def _scale_to_basis(self, X: np.ndarray) -> np.ndarray:
         lower, upper = self.feature_range_
         span = upper - lower
-        return ((X - lower) * 2.0 / span) - 1.0
+        scaled = ((X - lower) * 2.0 / span) - 1.0
+        return np.clip(scaled, -1.0, 1.0, out=scaled)
 
     def _evaluate_basis(self, X: np.ndarray) -> np.ndarray:
         if X.shape[1] == 0:


### PR DESCRIPTION
## Summary
- clip scaled Bernstein feature inputs to the unit interval to guard against floating point drift
- clip scaled Legendre feature inputs to [-1, 1] to avoid evaluating outside the intended domain

## Testing
- PYTHONPATH=src python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d772cb95bc832da33a441fe45af713